### PR TITLE
added auto env detection for public keys on client instantiation and fixed json unmarshaling bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,10 +39,13 @@ import (
   "github.com/fuadop/sendchamp"
 )
 
-var publicKey string = "your-public-key"
+var publicKey = &sendchamp.Keys{
+	PublicKey: "your-public-key",
+} //pass as nil to use the enviroment variable 'SENDCHAMP_PUBLIC_KEY'
 var mode string = sendchamp.ModeLive // can be set to test mode (sendchamp.ModeTest) too
 
 func main() {
+  //if the first parameter is nil, the package would look for the enviroment variable 'SENDCHAMP_PUBLIC_KEY'
   client := sendchamp.NewClient(publicKey, mode)
   
   sender := "sendchamp"
@@ -68,9 +71,11 @@ Checkout more examples in the test files and this example http server repo https
 ## SMS
 ### Initialize
 ```go
- publicKey := "public_key"
+ publicKey :=  &sendchamp.Keys{
+	PublicKey: "your-public-key",
+ } //pass as nil to use the enviroment variable 'SENDCHAMP_PUBLIC_KEY'
  mode := sendchamp.ModeLive
-
+ //if the first parameter is nil, the package would look for the enviroment variable 'SENDCHAMP_PUBLIC_KEY'
  client := sendchamp.NewClient(publicKey, mode)
  sms := client.NewSms()
 ```
@@ -138,9 +143,11 @@ sendchamp.UseCaseTransactionalAndMarketing = "transaction_marketing"
 ## Voice
 ### Initialize
 ```go
- publicKey := "public_key"
+ publicKey :=  &sendchamp.Keys{
+	PublicKey: "your-public-key",
+ } //pass as nil to use the enviroment variable 'SENDCHAMP_PUBLIC_KEY'
  mode := sendchamp.ModeLive
-
+ //if the first parameter is nil, the package would look for the enviroment variable 'SENDCHAMP_PUBLIC_KEY'
  client := sendchamp.NewClient(publicKey, mode)
  voice := client.NewVoice()
 ```
@@ -172,9 +179,11 @@ sendchamp.VoiceTypeOutgoing = "outgoing"
 ## Wallet
 ### Initialize
 ```go
- publicKey := "public_key"
+publicKey :=  &sendchamp.Keys{
+	PublicKey: "your-public-key",
+ } //pass as nil to use the enviroment variable 'SENDCHAMP_PUBLIC_KEY'
  mode := sendchamp.ModeLive
-
+ //if the first parameter is nil, the package would look for the enviroment variable 'SENDCHAMP_PUBLIC_KEY'
  client := sendchamp.NewClient(publicKey, mode)
 ```
 
@@ -201,9 +210,11 @@ sendchamp.VoiceTypeOutgoing = "outgoing"
 ## Verification
 ### Initialize
 ```go
- publicKey := "public_key"
+ publicKey :=  &sendchamp.Keys{
+	PublicKey: "your-public-key",
+ } //pass as nil to use the enviroment variable 'SENDCHAMP_PUBLIC_KEY'
  mode := sendchamp.ModeLive
-
+ //if the first parameter is nil, the package would look for the enviroment variable 'SENDCHAMP_PUBLIC_KEY'
  client := sendchamp.NewClient(publicKey, mode)
  verification := client.NewVerification()
 ```
@@ -274,9 +285,11 @@ sendchamp.OTPTypeAlphaNumeric = "alphanumeric"
 ## Whatsapp
 ### Initialize
 ```go
- publicKey := "public_key"
+publicKey :=  &sendchamp.Keys{
+	PublicKey: "your-public-key",
+ } //pass as nil to use the enviroment variable 'SENDCHAMP_PUBLIC_KEY'
  mode := sendchamp.ModeLive
-
+ //if the first parameter is nil, the package would look for the enviroment variable 'SENDCHAMP_PUBLIC_KEY'
  client := sendchamp.NewClient(publicKey, mode)
  whatsapp := client.NewWhatsapp()
 ```

--- a/sendchamp.go
+++ b/sendchamp.go
@@ -20,7 +20,7 @@ type Keys struct {
 }
 
 func NewClient(key *Keys, mode string) *Client {
-	var publicKey string = os.Getenv(("SENDCHAMP_PUBLIC_KEY"))
+	var publicKey string = os.Getenv("SENDCHAMP_PUBLIC_KEY")
 	if key != nil {
 		publicKey = key.PublicKey
 	}

--- a/sendchamp.go
+++ b/sendchamp.go
@@ -1,6 +1,9 @@
 package sendchamp
 
-import "net/http"
+import (
+	"net/http"
+	"os"
+)
 
 const (
 	URLLive           = "https://api.sendchamp.com/api/v1"
@@ -12,7 +15,16 @@ const (
 	ModeLocalSimulator = "local-simulator"
 )
 
-func NewClient(publicKey, mode string) *Client {
+type Keys struct {
+	PublicKey string
+}
+
+func NewClient(key *Keys, mode string) *Client {
+	var publicKey string = os.Getenv(("SENDCHAMP_PUBLIC_KEY"))
+	if key != nil {
+		publicKey = key.PublicKey
+	}
+
 	baseUrl := URLTest
 
 	if mode == ModeLive {

--- a/sms.go
+++ b/sms.go
@@ -42,7 +42,7 @@ type createSenderIdPayload struct {
 }
 
 type sendSmsResponse struct {
-	Status  string              `json:"status"`
+	Status  uint                `json:"status"`
 	Code    string              `json:"code"`
 	Message string              `json:"message"`
 	Data    sendSmsResponseData `json:"data"`

--- a/sms_test.go
+++ b/sms_test.go
@@ -9,7 +9,9 @@ import (
 	"github.com/fuadop/sendchamp"
 )
 
-var key string = os.Getenv("PUBLIC_KEY")
+var key = &sendchamp.Keys{
+	PublicKey: os.Getenv("PUBLIC_KEY"),
+}
 
 // todo: switch to test mode when it's back available
 var client sendchamp.Client = *sendchamp.NewClient(key, sendchamp.ModeLive)


### PR DESCRIPTION
For new instances of the client, I added the ability to automatically check for the environment variable "SENDCHAMP_PUBLIC_KEY" as a fallback to just passing in the key as a string.
This is useful because it gives people that do not wish to have their public keys directly in their code the opportunity to set an enviromental variable "SENDCHAMP_PUBLIC_KEY" and have the package automatically detect it from their OS environment and use it. 

`
publicKey :=  &sendchamp.Keys{
	PublicKey: "your-public-key",
 } //pass as nil to use the enviroment variable 'SENDCHAMP_PUBLIC_KEY'
 mode := sendchamp.ModeLive
 //if the first parameter is nil, the package would look for the enviroment variable 'SENDCHAMP_PUBLIC_KEY'
 client := sendchamp.NewClient(publicKey, mode)`

The behaviour is such that is is not compulsory, users can still pass in their public key as a string if they prefer. The library falls back to using the enviromental variable automatically when the user passes in `nil` . To support this, I created a new `Keys` struct with the field PublicKey. I called it `Keys` in case there is a need for extra keys in the future (secret, token etc.), they can all be classified under that struct. I also updated the necessary documentation in the readme and on the test.


There was also an error on the SMS related routes `json: cannot unmarshal number into Go struct field sendSmsResponse.status of type string` this was because the `smsResponse` struct had the status code field set to a type of string whilst the API was returning an int. I have also fixed that.