### PR TITLE
refactor http client into client.go

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@
 
 # Dependency directories (remove the comment below to include it)
 # vendor/
+
+.env

--- a/client.go
+++ b/client.go
@@ -1,6 +1,12 @@
 package sendchamp
 
-import "net/http"
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+)
 
 type Client struct {
 	baseURL    string
@@ -35,4 +41,52 @@ func (c *Client) NewWhatsapp() *Whatsapp {
 	return &Whatsapp{
 		client: c,
 	}
+}
+
+type Request struct {
+	Method string
+	URL    string
+}
+
+func (c *Client) NewRequest(method, url string) *Request {
+	return &Request{
+		Method: method,
+		URL: url,
+	}
+}
+
+func (c *Client) SendRequest(reqData *Request, payload interface{}) (b []byte, err error) {
+	var (
+		req  *http.Request
+		body *bytes.Buffer
+	)
+	if payload != nil {
+		jsonBytes, err := json.Marshal(payload)
+		if err != nil {
+			return nil, err
+		}
+		body = bytes.NewBuffer(jsonBytes)
+		req, err = http.NewRequest(reqData.Method, reqData.URL, body)
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		req, err = http.NewRequest(reqData.Method, reqData.URL, nil)
+		if err != nil {
+			return nil, err
+		}
+	}
+	req.Header.Add("Content-Type", "application/json")
+	req.Header.Add("Authorization", fmt.Sprintf(`Bearer %s`, c.publicKey))
+	client := &http.Client{}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	b, err = ioutil.ReadAll(resp.Body)
+	defer resp.Body.Close()
+	if err != nil {
+		return nil, err
+	}
+	return b, nil
 }

--- a/sms.go
+++ b/sms.go
@@ -1,7 +1,6 @@
 package sendchamp
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -42,7 +41,7 @@ type createSenderIdPayload struct {
 }
 
 type sendSmsResponse struct {
-	Status  uint                `json:"status"`
+	Status  uint              `json:"status"`
 	Code    string              `json:"code"`
 	Message string              `json:"message"`
 	Data    sendSmsResponseData `json:"data"`
@@ -70,7 +69,7 @@ type sendSmsResponseData struct {
 }
 
 type createSenderIDResponse struct {
-	Status  string                     `json:"status"`
+	Status  uint                     `json:"status"`
 	Code    string                     `json:"code"`
 	Message string                     `json:"message"`
 	Data    createSenderIDResponseData `json:"data"`
@@ -91,76 +90,44 @@ type GetDeliveryReport struct {
 // Send sms to one or many phone number
 func (s *Sms) Send(senderName string, to []string, message, route string) (sendSmsResponse, error) {
 	url := fmt.Sprint(s.client.baseURL, endpointSendSms)
-
 	// populate request body
-	byte, err := json.Marshal(sendSmsPayload{
+	payload := sendSmsPayload{
 		SenderName: senderName,
 		To:         to,
 		Message:    message,
 		Route:      route,
-	})
-
+	}
+	reqData := s.client.NewRequest(http.MethodPost, url)
+	resp, err := s.client.SendRequest(reqData, payload)
 	if err != nil {
 		return sendSmsResponse{}, err
 	}
-
-	req, err := http.NewRequest(http.MethodPost, url, bytes.NewReader(byte))
-
-	if err != nil {
-		return sendSmsResponse{}, err
-	}
-
-	// add necessary request headers
-	addHeaders(req, s.client)
-
-	res, err := s.client.httpClient.Do(req)
-	if err != nil {
-		return sendSmsResponse{}, err
-	}
-
-	defer res.Body.Close()
-
 	r := sendSmsResponse{}
-	err = json.NewDecoder(res.Body).Decode(&r)
+	err = json.Unmarshal(resp, &r)
 	if err != nil {
 		return sendSmsResponse{}, err
 	}
-
 	return r, nil
 }
 
 // Create a sender ID
 func (s *Sms) CreateSenderID(name, sample, useCase string) (createSenderIDResponse, error) {
 	url := fmt.Sprint(s.client.baseURL, endpointSenderID)
-
-	byte, err := json.Marshal(createSenderIdPayload{
+	payload := createSenderIdPayload{
 		Name:    name,
 		Sample:  sample,
 		UseCase: useCase,
-	})
+	}
+	reqData := s.client.NewRequest(http.MethodPost, url)
+	resp, err := s.client.SendRequest(reqData, payload)
 	if err != nil {
 		return createSenderIDResponse{}, err
 	}
-
-	req, err := http.NewRequest(http.MethodPost, url, bytes.NewReader(byte))
-	if err != nil {
-		return createSenderIDResponse{}, err
-	}
-
-	addHeaders(req, s.client)
-
-	res, err := s.client.httpClient.Do(req)
-	if err != nil {
-		return createSenderIDResponse{}, err
-	}
-
-	defer res.Body.Close()
 	r := createSenderIDResponse{}
-	err = json.NewDecoder(res.Body).Decode(&r)
+	err = json.Unmarshal(resp, &r)
 	if err != nil {
 		return createSenderIDResponse{}, err
 	}
-
 	return r, nil
 }
 
@@ -170,45 +137,28 @@ func (s *Sms) CreateSenderID(name, sample, useCase string) (createSenderIDRespon
 // smsID = res.Data.ID from sms.Send method
 func (s *Sms) GetDeliveryReport(smsID string) (sendSmsResponse, error) {
 	url := fmt.Sprint(s.client.baseURL, endpointDeliveryReport, smsID)
-
-	req, err := http.NewRequest(http.MethodGet, url, nil)
+	reqData := s.client.NewRequest(http.MethodGet, url)
+	resp, err := s.client.SendRequest(reqData, nil)
 	if err != nil {
 		return sendSmsResponse{}, err
 	}
-
-	addHeaders(req, s.client)
-	res, err := s.client.httpClient.Do(req)
-	if err != nil {
-		return sendSmsResponse{}, err
-	}
-
-	defer res.Body.Close()
 	r := sendSmsResponse{}
-	err = json.NewDecoder(res.Body).Decode(&r)
+	err = json.Unmarshal(resp, &r)
 	if err != nil {
 		return sendSmsResponse{}, err
 	}
-
 	return r, nil
 }
 
 func (s *Sms) GetBulkDeliveryReport(bulkSmsUID string) (sendSmsResponse, error) {
 	url := fmt.Sprint(s.client.baseURL, endpointDeliveryReport, bulkSmsUID)
-
-	req, err := http.NewRequest(http.MethodGet, url, nil)
+	reqData := s.client.NewRequest(http.MethodGet, url)
+	resp, err := s.client.SendRequest(reqData, nil)
 	if err != nil {
 		return sendSmsResponse{}, err
 	}
-
-	addHeaders(req, s.client)
-	res, err := s.client.httpClient.Do(req)
-	if err != nil {
-		return sendSmsResponse{}, err
-	}
-
-	defer res.Body.Close()
 	r := sendSmsResponse{}
-	err = json.NewDecoder(res.Body).Decode(&r)
+	err = json.Unmarshal(resp, &r)
 	if err != nil {
 		return sendSmsResponse{}, err
 	}

--- a/sms_test.go
+++ b/sms_test.go
@@ -22,7 +22,7 @@ func TestSendSms(t *testing.T) {
 		t.Error(err)
 	}
 
-	if res.Status != "success" {
+	if res.Status != 200 {
 		t.Error("res.Status: ", res.Status)
 	}
 }
@@ -34,7 +34,7 @@ func TestCreateSenderID(t *testing.T) {
 		t.Error(err)
 	}
 
-	if res.Status != "success" {
+	if res.Status != 200 {
 		t.Error("res.Status: ", res.Status)
 	}
 }
@@ -53,7 +53,7 @@ func TestGetDeliveryReport(t *testing.T) {
 		if err != nil {
 			t.Error(err)
 		}
-		if resp.Status != "success" {
+		if resp.Status != 200 {
 			t.Error("res.Status: ", resp.Status)
 		}
 
@@ -77,7 +77,7 @@ func TestGetBulkDeliveryReport(t *testing.T) {
 		t.Error(err)
 	}
 
-	if resp.Status != "success" {
+	if resp.Status != 200 {
 		t.Error("res.Status: ", resp.Status)
 	}
 

--- a/verification_test.go
+++ b/verification_test.go
@@ -29,8 +29,8 @@ func TestSendOTP(t *testing.T) {
 		t.Error(err)
 	}
 
-	if res.Status != "success" {
-		t.Errorf("res.Status: %s", res.Status)
+	if res.Status != 200 {
+		t.Errorf("res.Status: %v", res.Status)
 	}
 
 	payload = sendchamp.SendOTPPayload{
@@ -49,8 +49,8 @@ func TestSendOTP(t *testing.T) {
 		t.Error(err)
 	}
 
-	if res.Status != "success" {
-		t.Errorf("res.Status: %s", res.Status)
+	if res.Status != 200 {
+		t.Errorf("res.Status: %v", res.Status)
 	}
 }
 
@@ -60,7 +60,7 @@ func TestConfirmOTP(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	if res.Status != "success" {
-		t.Errorf("res.Status: %s", res.Status)
+	if res.Status != 200 {
+		t.Errorf("res.Status: %v", res.Status)
 	}
 }

--- a/voice_test.go
+++ b/voice_test.go
@@ -18,7 +18,7 @@ func TestSendVoice(t *testing.T) {
 		t.Error(err)
 	}
 
-	if res.Status != "success" {
+	if res.Status != 200 {
 		t.Error("res.Status: ", res.Status)
 	}
 

--- a/wallet.go
+++ b/wallet.go
@@ -11,7 +11,7 @@ const (
 )
 
 type walletBalanceResponse struct {
-	Status  string                    `json:"status"`
+	Status  uint                    `json:"status"`
 	Code    string                    `json:"code"`
 	Message string                    `json:"message"`
 	Data    walletBalanceResponseData `json:"data"`
@@ -37,24 +37,13 @@ type walletBalanceResponseDataDetails struct {
 
 func (c *Client) WalletBalance() (walletBalanceResponse, error) {
 	url := fmt.Sprint(c.baseURL, endpointWalletBalance)
-
-	req, err := http.NewRequest(http.MethodGet, url, nil)
+	reqData := c.NewRequest(http.MethodGet, url)
+	resp, err := c.SendRequest(reqData, nil)
 	if err != nil {
 		return walletBalanceResponse{}, err
 	}
-
-	// add necessary request headers
-	addHeaders(req, c)
-
-	res, err := c.httpClient.Do(req)
-	if err != nil {
-		return walletBalanceResponse{}, err
-	}
-
-	defer res.Body.Close()
-
 	r := walletBalanceResponse{}
-	err = json.NewDecoder(res.Body).Decode(&r)
+	err = json.Unmarshal(resp, &r)
 	if err != nil {
 		return walletBalanceResponse{}, err
 	}

--- a/wallet_test.go
+++ b/wallet_test.go
@@ -10,7 +10,7 @@ func TestWalletBalance(t *testing.T) {
 		t.Error(err)
 	}
 
-	if res.Status != "success" {
+	if res.Status != 200 {
 		t.Error("res.Status: ", res.Status)
 	}
 }

--- a/whatsapp.go
+++ b/whatsapp.go
@@ -1,7 +1,6 @@
 package sendchamp
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -67,7 +66,7 @@ type sendLocationPayload struct {
 	Address   string  `json:"address"`
 }
 type sendTemplateResponse struct {
-	Status  string                   `json:"status"`
+	Status  uint                   `json:"status"`
 	Code    string                   `json:"code"`
 	Message string                   `json:"message"`
 	Data    sendTemplateResponseData `json:"data"`
@@ -83,8 +82,7 @@ type sendTemplateResponseData struct {
 // template created on dashboard.
 func (w *Whatsapp) SendTemplate(sender, recipient, templateCode string, data map[string]string) (sendTemplateResponse, error) {
 	url := fmt.Sprint(w.client.baseURL, endpointSendWhatsapp)
-
-	byte, err := json.Marshal(sendTemplatePayload{
+	payload := sendTemplatePayload{
 		Recipient:    recipient,
 		Sender:       sender,
 		Type:         WhatsappTypeTemplate,
@@ -92,26 +90,14 @@ func (w *Whatsapp) SendTemplate(sender, recipient, templateCode string, data map
 		CustomData: customData{
 			Body: data,
 		},
-	})
-
+	}
+	reqData := w.client.NewRequest(http.MethodPost, url)
+	resp, err := w.client.SendRequest(reqData, payload)
 	if err != nil {
 		return sendTemplateResponse{}, err
 	}
-
-	req, err := http.NewRequest(http.MethodPost, url, bytes.NewReader(byte))
-	if err != nil {
-		return sendTemplateResponse{}, err
-	}
-
-	addHeaders(req, w.client)
-	res, err := w.client.httpClient.Do(req)
-	if err != nil {
-		return sendTemplateResponse{}, err
-	}
-
-	defer res.Body.Close()
 	r := sendTemplateResponse{}
-	err = json.NewDecoder(res.Body).Decode(&r)
+	err = json.Unmarshal(resp, &r)
 	if err != nil {
 		return sendTemplateResponse{}, err
 	}
@@ -122,30 +108,19 @@ func (w *Whatsapp) SendTemplate(sender, recipient, templateCode string, data map
 // SendText - Send a whatsapp text.
 func (w *Whatsapp) SendText(sender, recipient, message string) (sendTemplateResponse, error) {
 	url := fmt.Sprint(w.client.baseURL, endpointSendWhatsapp)
-	byte, err := json.Marshal(sendTextPayload{
+	payload := sendTextPayload{
 		Recipient: recipient,
 		Sender:    sender,
 		Type:      WhatsappTypeText,
 		Message:   message,
-	})
+	}
+	reqData := w.client.NewRequest(http.MethodPost, url)
+	resp, err := w.client.SendRequest(reqData, payload)
 	if err != nil {
 		return sendTemplateResponse{}, err
 	}
-
-	req, err := http.NewRequest(http.MethodPost, url, bytes.NewReader(byte))
-	if err != nil {
-		return sendTemplateResponse{}, err
-	}
-
-	addHeaders(req, w.client)
-	res, err := w.client.httpClient.Do(req)
-	if err != nil {
-		return sendTemplateResponse{}, err
-	}
-
-	defer res.Body.Close()
 	r := sendTemplateResponse{}
-	err = json.NewDecoder(res.Body).Decode(&r)
+	err = json.Unmarshal(resp, &r)
 	if err != nil {
 		return sendTemplateResponse{}, err
 	}
@@ -156,31 +131,20 @@ func (w *Whatsapp) SendText(sender, recipient, message string) (sendTemplateResp
 // SendAudio - Send a whatsapp audio message.
 func (w *Whatsapp) SendAudio(sender, recipient, message, link string) (sendTemplateResponse, error) {
 	url := fmt.Sprint(w.client.baseURL, endpointSendWhatsapp)
-	byte, err := json.Marshal(sendAudioPayload{
+	payload := sendAudioPayload{
 		Recipient: recipient,
 		Sender:    sender,
 		Type:      WhatsappTypeAudio,
 		Message:   message,
 		Link:      link,
-	})
+	}
+	reqData := w.client.NewRequest(http.MethodPost, url)
+	resp, err := w.client.SendRequest(reqData, payload)
 	if err != nil {
 		return sendTemplateResponse{}, err
 	}
-
-	req, err := http.NewRequest(http.MethodPost, url, bytes.NewReader(byte))
-	if err != nil {
-		return sendTemplateResponse{}, err
-	}
-
-	addHeaders(req, w.client)
-	res, err := w.client.httpClient.Do(req)
-	if err != nil {
-		return sendTemplateResponse{}, err
-	}
-
-	defer res.Body.Close()
 	r := sendTemplateResponse{}
-	err = json.NewDecoder(res.Body).Decode(&r)
+	err = json.Unmarshal(resp, &r)
 	if err != nil {
 		return sendTemplateResponse{}, err
 	}
@@ -191,30 +155,19 @@ func (w *Whatsapp) SendAudio(sender, recipient, message, link string) (sendTempl
 // SendVideo - Send a whatsapp video message.
 func (w *Whatsapp) SendVideo(sender, recipient, link string) (sendTemplateResponse, error) {
 	url := fmt.Sprint(w.client.baseURL, endpointSendWhatsapp)
-	byte, err := json.Marshal(sendVideoPayload{
+	payload := sendVideoPayload{
 		Recipient: recipient,
 		Sender:    sender,
 		Type:      WhatsappTypeVideo,
 		Link:      link,
-	})
+	}
+	reqData := w.client.NewRequest(http.MethodPost, url)
+	resp, err := w.client.SendRequest(reqData, payload)
 	if err != nil {
 		return sendTemplateResponse{}, err
 	}
-
-	req, err := http.NewRequest(http.MethodPost, url, bytes.NewReader(byte))
-	if err != nil {
-		return sendTemplateResponse{}, err
-	}
-
-	addHeaders(req, w.client)
-	res, err := w.client.httpClient.Do(req)
-	if err != nil {
-		return sendTemplateResponse{}, err
-	}
-
-	defer res.Body.Close()
 	r := sendTemplateResponse{}
-	err = json.NewDecoder(res.Body).Decode(&r)
+	err = json.Unmarshal(resp, &r)
 	if err != nil {
 		return sendTemplateResponse{}, err
 	}
@@ -225,30 +178,19 @@ func (w *Whatsapp) SendVideo(sender, recipient, link string) (sendTemplateRespon
 // SendSticker - Send a whatsapp sticker message.
 func (w *Whatsapp) SendSticker(sender, recipient, link string) (sendTemplateResponse, error) {
 	url := fmt.Sprint(w.client.baseURL, endpointSendWhatsapp)
-	byte, err := json.Marshal(sendVideoPayload{
+	payload := sendVideoPayload{
 		Recipient: recipient,
 		Sender:    sender,
 		Type:      WhatsappTypeSticker,
 		Link:      link,
-	})
+	}
+	reqData := w.client.NewRequest(http.MethodPost, url)
+	resp, err := w.client.SendRequest(reqData, payload)
 	if err != nil {
 		return sendTemplateResponse{}, err
 	}
-
-	req, err := http.NewRequest(http.MethodPost, url, bytes.NewReader(byte))
-	if err != nil {
-		return sendTemplateResponse{}, err
-	}
-
-	addHeaders(req, w.client)
-	res, err := w.client.httpClient.Do(req)
-	if err != nil {
-		return sendTemplateResponse{}, err
-	}
-
-	defer res.Body.Close()
 	r := sendTemplateResponse{}
-	err = json.NewDecoder(res.Body).Decode(&r)
+	err = json.Unmarshal(resp, &r)
 	if err != nil {
 		return sendTemplateResponse{}, err
 	}
@@ -259,7 +201,7 @@ func (w *Whatsapp) SendSticker(sender, recipient, link string) (sendTemplateResp
 // SendLocation - Send a location via whatsapp.
 func (w *Whatsapp) SendLocation(sender, recipient string, longitude, latitude float64, name, address string) (sendTemplateResponse, error) {
 	url := fmt.Sprint(w.client.baseURL, endpointSendWhatsapp)
-	byte, err := json.Marshal(sendLocationPayload{
+	payload := sendLocationPayload{
 		Recipient: recipient,
 		Sender:    sender,
 		Type:      WhatsappTypeLocation,
@@ -267,25 +209,14 @@ func (w *Whatsapp) SendLocation(sender, recipient string, longitude, latitude fl
 		Longitude: longitude,
 		Name:      name,
 		Address:   address,
-	})
+	}
+	reqData := w.client.NewRequest(http.MethodPost, url)
+	resp, err := w.client.SendRequest(reqData, payload)
 	if err != nil {
 		return sendTemplateResponse{}, err
 	}
-
-	req, err := http.NewRequest(http.MethodPost, url, bytes.NewReader(byte))
-	if err != nil {
-		return sendTemplateResponse{}, err
-	}
-
-	addHeaders(req, w.client)
-	res, err := w.client.httpClient.Do(req)
-	if err != nil {
-		return sendTemplateResponse{}, err
-	}
-
-	defer res.Body.Close()
 	r := sendTemplateResponse{}
-	err = json.NewDecoder(res.Body).Decode(&r)
+	err = json.Unmarshal(resp, &r)
 	if err != nil {
 		return sendTemplateResponse{}, err
 	}

--- a/whatsapp_test.go
+++ b/whatsapp_test.go
@@ -19,7 +19,7 @@ func TestSendTemplate(t *testing.T) {
 		t.Error(err)
 	}
 
-	if res.Status != "success" {
+	if res.Status != 200 {
 		t.Error("res.Status: ", res.Status)
 	}
 }
@@ -34,7 +34,7 @@ func TestSendText(t *testing.T) {
 		t.Error(err)
 	}
 
-	if res.Status != "success" {
+	if res.Status != 200 {
 		t.Error("res.Status: ", res.Status)
 	}
 }
@@ -50,7 +50,7 @@ func TestSendAudio(t *testing.T) {
 		t.Error(err)
 	}
 
-	if res.Status != "success" {
+	if res.Status != 200 {
 		t.Error("res.Status: ", res.Status)
 	}
 }
@@ -65,7 +65,7 @@ func TestSendVideo(t *testing.T) {
 		t.Error(err)
 	}
 
-	if res.Status != "success" {
+	if res.Status != 200 {
 		t.Error("res.Status: ", res.Status)
 	}
 }
@@ -80,7 +80,7 @@ func TestSendSticker(t *testing.T) {
 		t.Error(err)
 	}
 
-	if res.Status != "success" {
+	if res.Status != 200 {
 		t.Error("res.Status: ", res.Status)
 	}
 }
@@ -98,7 +98,7 @@ func TestSendLocation(t *testing.T) {
 		t.Error(err)
 	}
 
-	if res.Status != "success" {
+	if res.Status != 200 {
 		t.Error("res.Status: ", res.Status)
 	}
 }


### PR DESCRIPTION
- I refactored the http request out from each function into the client.go file, this reduces repeated code.
- I updated the 'Status' field in the response structs to unit because the test failed as the response coming from the API is not a string as used initially.